### PR TITLE
feat: update home page version and date

### DIFF
--- a/i18n/en-us/docusaurus-theme-classic/footer.json
+++ b/i18n/en-us/docusaurus-theme-classic/footer.json
@@ -4,7 +4,7 @@
     "description": "The label of footer link with label=Blog linking to /blog"
   },
   "copyright": {
-    "message": "Copyright © 2023 Spring Cloud Alibaba<br />浙公网安备 33011002016922号 浙ICP备12022327号-1119",
+    "message": "Copyright © 2024 Spring Cloud Alibaba<br />浙公网安备 33011002016922号 浙ICP备12022327号-1119",
     "description": "The footer copyright"
   },
   "link.title.Vision": {

--- a/i18n/zh-cn/docusaurus-theme-classic/footer.json
+++ b/i18n/zh-cn/docusaurus-theme-classic/footer.json
@@ -4,7 +4,7 @@
     "description": "The label of footer link with label=Blog linking to /blog"
   },
   "copyright": {
-    "message": "Copyright © 2023 Spring Cloud Alibaba<br />浙公网安备 33011002016922号 浙ICP备12022327号-1119",
+    "message": "Copyright © 2024 Spring Cloud Alibaba<br />浙公网安备 33011002016922号 浙ICP备12022327号-1119",
     "description": "The footer copyright"
   },
   "link.title.Vision": {

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -73,7 +73,7 @@ const data = {
       },
     ],
   },
-  copyright: "Copyright © 2023 Spring Cloud Alibaba",
+  copyright: `Copyright © ${new Date().getFullYear()} Spring Cloud Alibaba`,
 };
 
 type Props = {

--- a/src/pages/home/top/index.tsx
+++ b/src/pages/home/top/index.tsx
@@ -21,7 +21,7 @@ const topData = {
   buttons: [
     {
       text: translate({ id: "homepage.quickstartButton", message: "快速入门" }),
-      link: "/docs/2022.0.0.0/user-guide/nacos/quick-start",
+      link: "/docs/2023.0.0.0-RC1/user-guide/nacos/quick-start",
       type: "normal",
     },
     {
@@ -32,10 +32,10 @@ const topData = {
     },
   ],
   versionNote: {
-    text: "Release Note of 2022.0.0.0",
-    link: "https://github.com/alibaba/spring-cloud-alibaba/tree/2022.0.0.0",
+    text: "Release Note of 2023.0.0.0-RC1",
+    link: "https://github.com/alibaba/spring-cloud-alibaba/tree/2023.0.0.0-RC1",
   },
-  releaseDate: "Released on March 22, 2023",
+  releaseDate: "Released on Feb 20, 2024",
 };
 
 const Top = ({ language }: { language?: string }) => {

--- a/src/pages/home/top/index.tsx
+++ b/src/pages/home/top/index.tsx
@@ -35,7 +35,7 @@ const topData = {
     text: "Release Note of 2023.0.0.0-RC1",
     link: "https://github.com/alibaba/spring-cloud-alibaba/tree/2023.0.0.0-RC1",
   },
-  releaseDate: "Released on Feb 20, 2024",
+  releaseDate: "Released on Feb 26, 2024",
 };
 
 const Top = ({ language }: { language?: string }) => {


### PR DESCRIPTION
Changes:

- home page quick-start link
- home page release note
- home page copyright

Screenshots of the change:

<img width="1512" alt="image" src="https://github.com/spring-cloud-alibaba-group/spring-cloud-alibaba-group.github.io/assets/49056040/dcd3ffbb-e8c0-4c2c-83a7-53a207624e2d">

<img width="1512" alt="image" src="https://github.com/spring-cloud-alibaba-group/spring-cloud-alibaba-group.github.io/assets/49056040/41088af9-aa45-4ec8-8d99-a780d8e54f2d">
