### PR TITLE
fix: editUrl 404

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -108,7 +108,8 @@ const config = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl: ({locale, version, docPath }) => {
-            return `https://github.com/spring-cloud-alibaba-group/spring-cloud-alibaba-group.github.io/blob/master/i18n/${locale}/docusaurus-plugin-content-docs/version-${version}/${docPath}`;
+            version = version === "current" ? "current" : "version-" + version
+            return `https://github.com/spring-cloud-alibaba-group/spring-cloud-alibaba-group.github.io/blob/master/i18n/${locale}/docusaurus-plugin-content-docs/${version}/${docPath}`;
           },
           
           // last version 


### PR DESCRIPTION
Changes:

- doc editUrl 404
- blog editUrl 404

Screenshots of the change:

<img width="1512" alt="image" src="https://github.com/spring-cloud-alibaba-group/spring-cloud-alibaba-group.github.io/assets/49056040/4534197d-8a21-4478-b7e4-5e16f0134604">

<img width="1512" alt="image" src="https://github.com/spring-cloud-alibaba-group/spring-cloud-alibaba-group.github.io/assets/49056040/de7fa547-981a-49cc-88de-cb0f25fd9234">